### PR TITLE
update deps and clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,25 +9,25 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.13"
-bech32 = "0.8"
-bytes = "1.0"
-cosmos-sdk-proto = { package = "cosmos-sdk-proto-althea", version = "0.9" }
+bech32 = "0.9"
+bytes = "1.2"
+cosmos-sdk-proto = { package = "cosmos-sdk-proto-althea", version = "0.13" }
 hmac = { version = "0.12" }
 log = "0.4"
 num = "0.4"
-pbkdf2 = { version = "0.10" }
-prost = "0.9"
-prost-types = "0.9"
+pbkdf2 = { version = "0.11" }
+prost = "0.10"
+prost-types = "0.10"
 rand = { version = "0.8" }
 ripemd = "0.1"
-rust_decimal = "1.9"
-secp256k1 = "0.21"
+rust_decimal = "1.26"
+secp256k1 = "0.24"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
-tokio = { version = "1.17", features = ["time"] }
-tonic = { version = "0.6", features = ["compression"] }
+tokio = { version = "1.20", features = ["time"] }
+tonic = { version = "0.7", features = ["compression"] }
 u64_array_bigints = { version = "0.3", default-features = false, features = ["serde_support"] }
 unicode-normalization = { version = "0.1" }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,6 +27,7 @@ pub const PAGE: Option<PageRequest> = Some(PageRequest {
     offset: 0,
     limit: PAGE_SIZE,
     count_total: false,
+    reverse: false,
 });
 
 /// An instance of Contact Cosmos RPC Client.

--- a/src/error.rs
+++ b/src/error.rs
@@ -203,7 +203,7 @@ impl From<bech32::Error> for AddressError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ByteDecodeError {
     DecodeError(Utf8Error),
     ParseError(ParseIntError),

--- a/src/mnemonic/language/mod.rs
+++ b/src/mnemonic/language/mod.rs
@@ -187,7 +187,7 @@ mod tests {
                 hasher.update(format!("{}\n", word));
             }
             assert_eq!(
-                bytes_to_hex_str(&hasher.finalize().to_vec()),
+                bytes_to_hex_str(&hasher.finalize()),
                 sum,
                 "word list for language {} failed checksum check",
                 lang,

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -64,16 +64,15 @@ impl PublicKey {
     /// Create an address object using a given public key.
     pub fn to_address(&self) -> Address {
         let current_prefix = self.get_prefix();
-        let new_prefix;
         // Cosmos has the format cosmospub -> cosmos which we
         // attempt to keep the convention here, note that other
         // conventions may come out with the wrong prefix by default
         // that's up to the caller to fix
-        if current_prefix.ends_with("pub") {
-            new_prefix = current_prefix.trim_end_matches("pub");
+        let new_prefix = if current_prefix.ends_with("pub") {
+            current_prefix.trim_end_matches("pub")
         } else {
-            new_prefix = &current_prefix;
-        }
+            &current_prefix
+        };
         // unwrap, the only failure possibility is if the Prefix is bad
         // and our own prefix can't possibly be bad, we've already validated it
         // and only reduced it's length since then

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -188,6 +188,7 @@ mod tests {
             gas_wanted: 0,
             tx: None,
             timestamp: String::new(),
+            events: Vec::new(),
         };
         let correct_output = Some(FeeInfo::InsufficientFees {
             min_fees: vec![


### PR DESCRIPTION
`add_assign` was deprecated, and I know `Scalar::from_be...` is correct because the `le` version causes test failures
